### PR TITLE
Update DefaultApps.ps1

### DIFF
--- a/DefaultApps.ps1
+++ b/DefaultApps.ps1
@@ -36,7 +36,7 @@ function Disable-InternetExplorerESC {
     $UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
     Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0
     Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 1
-    Stop-Process -Name Explorer
+    Stop-Process -Name Explorer -Force
 }
 # Disable ESC
 Disable-InternetExplorerESC


### PR DESCRIPTION
Stop-process is an interactive operation requiring confirmation. This causes the script to hang at the end and not compete. Custom script extension is left in failure or transition state indefinitely. Added Force switch to proceed without waiting